### PR TITLE
Use private keys correctly in local mode

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -429,8 +429,8 @@ func applyFn(ctx context.Context) error {
 		} else {
 
 			pemFile := ""
-			if connInfo.PrivateKey == "" {
-				pemFile, err := p.local_writePem(o, connInfo)
+			if connInfo.PrivateKey != "" {
+				pemFile, err = p.local_writePem(o, connInfo)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fix two small bugs that were preventing private keys from the connection info from being used by the provisioner when running in local mode.