### PR TITLE
Encapsulate bastion host metadata, restore --become-user to be source…

### DIFF
--- a/mode/bastion_host.go
+++ b/mode/bastion_host.go
@@ -1,0 +1,52 @@
+package mode
+
+// BastionHost encapsulates bastion host metadata.
+type BastionHost struct {
+	host    string
+	port    int
+	user    string
+	pemFile string
+}
+
+// NewBastionHostFromConnectionInfo returns a bastion host instance extracted from connection info.
+func NewBastionHostFromConnectionInfo(connInfo *connectionInfo, pemFile string) *BastionHost {
+	bastionHost := &BastionHost{
+		host:    "",
+		port:    connInfo.Port,
+		user:    connInfo.User,
+		pemFile: pemFile,
+	}
+	if connInfo.BastionHost != "" {
+		bastionHost.host = connInfo.BastionHost
+		if connInfo.BastionUser != "" {
+			bastionHost.user = connInfo.BastionUser
+		}
+		if connInfo.BastionPrivateKey != "" {
+			bastionHost.pemFile = connInfo.BastionPrivateKey
+		}
+		if connInfo.BastionPort > 0 {
+			bastionHost.port = connInfo.BastionPort
+		}
+	}
+	return bastionHost
+}
+
+// Host returns bastion's host.
+func (v *BastionHost) Host() string {
+	return v.host
+}
+
+// Port returns bastion's port.
+func (v *BastionHost) Port() int {
+	return v.port
+}
+
+// User returns bastion's user.
+func (v *BastionHost) User() string {
+	return v.user
+}
+
+// PemFile returns bastion's PEM file.
+func (v *BastionHost) PemFile() string {
+	return v.pemFile
+}

--- a/mode/mode_remote.go
+++ b/mode/mode_remote.go
@@ -119,7 +119,7 @@ func (v *RemoteMode) Run(plays []*types.Play) error {
 	}
 
 	for _, play := range plays {
-		command, err := play.ToCommand()
+		command, err := play.ToCommand(types.LocalModeAnsibleArgs{})
 		if err != nil {
 			return err
 		}

--- a/types/play.go
+++ b/types/play.go
@@ -319,7 +319,7 @@ func (v *Play) defaultRolePaths() []string {
 }
 
 // ToCommand serializes the play to an executable Ansible command.
-func (v *Play) ToCommand() (string, error) {
+func (v *Play) ToCommand(ansibleArgs LocalModeAnsibleArgs) (string, error) {
 
 	command := ""
 	// entity to call:
@@ -392,7 +392,7 @@ func (v *Play) ToCommand() (string, error) {
 		if v.BecomeUser() != "" {
 			command = fmt.Sprintf("%s --become-user='%s'", command, v.BecomeUser())
 		} else {
-			command = fmt.Sprintf("%s --become-user='%s'", command, "") // $$ TODO: fix empty string from connection info
+			command = fmt.Sprintf("%s --become-user='%s'", command, ansibleArgs.Username)
 		}
 	}
 	// extra vars:
@@ -425,7 +425,7 @@ func (v *Play) ToCommand() (string, error) {
 
 // ToLocalCommand serializes the play to an executable local provisioning Ansible command.
 func (v *Play) ToLocalCommand(ansibleArgs LocalModeAnsibleArgs, ansibleSSHSettings *AnsibleSSHSettings) (string, error) {
-	baseCommand, err := v.ToCommand()
+	baseCommand, err := v.ToCommand(ansibleArgs)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
…d from connection info, when --become is true and no --become-user provided.

### Summary

Restores all functionality for local provisioning with a bastion host.

### Other Information

It was necessary to pass `LocalModeAnsibleArgs` to `Play.ToCommand`.