### PR TITLE
Vault ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ resource "aws_instance" "test_box" {
       forks = 5
       inventory_file = "/optional/inventory/file/path"
       limit = "limit"
-      vault_password_file = "/vault/password/file/path"
+      vault_id = ["/vault/password/file/path"]
       verbose = false
     }
     plays {
@@ -117,7 +117,7 @@ resource "aws_instance" "test_box" {
       forks = 5
       inventory_file = "/optional/inventory/file/path"
       limit = "limit"
-      vault_password_file = "/vault/password/file/path"
+      vault_id = ["/vault/password/file/path"]
     }
     ansible_ssh_settings {
       connect_timeout_seconds = 10
@@ -169,7 +169,8 @@ Each `plays` may contain at most one `playbook` or `module`. Define multiple `pl
 - `plays.forks`: `ansible[-playbook] --forks`, integer, default `5`
 - `plays.inventory_file`: full path to an inventory file, `ansible[-playbook] --inventory-file`, string, default `empty string`; if `inventory_file` attribute is not given or empty, a temporary inventory using `hosts` and `groups` will be generated; when specified, `hosts` and `groups` are not in use
 - `plays.limit`: `ansible[-playbook] --limit`, string, default `empty string` (not applied)
-- `plays.vault_password_file`: `ansible-playbook --vault-password-file`, full path to the vault password file; file file will be uploaded to the server, string, default `empty string` (not applied)
+- `plays.vault_id`: `ansible[-playbook] --vault-id`, list of full paths to vault password files; files will be uploaded to the server, string list, default `empty list` (not applied); takes precedence over `plays.vault_password_file`
+- `plays.vault_password_file`: `ansible[-playbook] --vault-password-file`, full path to the vault password file; file will be uploaded to the server, string, default `empty string` (not applied)
 - `plays.verbose`: `ansible[-playbook] --verbose`, boolean, default `false` (not applied)
 
 #### Defaults
@@ -184,6 +185,7 @@ Some of the `plays` settings might be common along multiple `plays`. Such settin
 - `defaults.forks`
 - `defaults.inventory_file`
 - `defaults.limit`
+- `defaults.vault_id`
 - `defaults.vault_password_file`
 
 None of the boolean attributes can be specified in `defaults`. Neither `playbook` nor `module` can be specified in `defaults`.
@@ -288,12 +290,19 @@ Remote provisioning works with a Linux target host only.
 
 ## Changes from 1.0.0
 
+### Breaking changes
+
 - change `plays.playbook` and `plays.module` to a resource
 - remove `yes/no` strings, boolean values are used instead
 - **local provisioning becomes the default**, remote provisioning enabled with `remote {}` resource
 - default values now provided using the `defaults` resource
 - added `ansible_ssh_settings {}` resource
 - `diff`, `become` and `verbose` can be set only on `plays`, no default override for boolean values
+
+### New features
+
+- added `--diff` support
+- added `--vault_id` support
 
 ## Creating releases
 

--- a/types/defaults.go
+++ b/types/defaults.go
@@ -14,6 +14,7 @@ type Defaults struct {
 	forks             int
 	inventoryFile     string
 	limit             string
+	vaultID           []string
 	vaultPasswordFile string
 	//
 	hostsIsSet             bool
@@ -24,6 +25,7 @@ type Defaults struct {
 	forksIsSet             bool
 	inventoryFileIsSet     bool
 	limitIsSet             bool
+	vaultIDIsSet           bool
 	vaultPasswordFileIsSet bool
 }
 
@@ -37,6 +39,7 @@ const (
 	defaultsAttributeForks             = "forks"
 	defaultsAttributeInventoryFile     = "inventory_file"
 	defaultsAttributeLimit             = "limit"
+	defaultsAttributeVaultID           = "vault_id"
 	defaultsAttributeVaultPasswordFile = "vault_password_file"
 )
 
@@ -84,10 +87,17 @@ func NewDefaultsSchema() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
+				defaultsAttributeVaultID: &schema.Schema{
+					Type:          schema.TypeList,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					Optional:      true,
+					ConflictsWith: []string{"defaults.vault_password_file"},
+				},
 				defaultsAttributeVaultPasswordFile: &schema.Schema{
-					Type:         schema.TypeString,
-					Optional:     true,
-					ValidateFunc: vfPath,
+					Type:          schema.TypeString,
+					Optional:      true,
+					ValidateFunc:  vfPath,
+					ConflictsWith: []string{"defaults.vault_id"},
 				},
 			},
 		},
@@ -130,6 +140,10 @@ func NewDefaultsFromInterface(i interface{}, ok bool) *Defaults {
 		if val, ok := vals[defaultsAttributeLimit]; ok {
 			v.limit = val.(string)
 			v.limitIsSet = v.limit != ""
+		}
+		if val, ok := vals[defaultsAttributeVaultID]; ok {
+			v.vaultID = listOfInterfaceToListOfString(val.([]interface{}))
+			v.vaultIDIsSet = len(v.vaultID) > 0
 		}
 		if val, ok := vals[defaultsAttributeVaultPasswordFile]; ok {
 			v.vaultPasswordFile = val.(string)

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -97,7 +98,7 @@ func listOfInterfaceToListOfString(v interface{}) []string {
 func ResolvePath(path string) (string, error) {
 	expandedPath, _ := homedir.Expand(path)
 	if _, err := os.Stat(expandedPath); err == nil {
-		return expandedPath, nil
+		return filepath.Clean(expandedPath), nil
 	}
 	return "", fmt.Errorf("Ansible module not found at path: [%s]", path)
 }
@@ -109,7 +110,7 @@ func ResolveDirectory(path string) (string, error) {
 		if !stat.IsDir() {
 			return "", fmt.Errorf("Path [%s] must be a directory", path)
 		}
-		return expandedPath, nil
+		return filepath.Clean(expandedPath), nil
 	}
 	return "", fmt.Errorf("Ansible module not found at path: [%s]", path)
 }


### PR DESCRIPTION
### Summary

Add `vault_id` support.

### Other Information

`vault_id` takes precedence over `vault_password_file` when generating Ansible commands.