### PR TITLE
Correct loading of private keys in local mode

### DIFF
--- a/mode/mode_local.go
+++ b/mode/mode_local.go
@@ -80,7 +80,8 @@ func (v *LocalMode) Run(plays []*types.Play, ansibleSSHSettings *types.AnsibleSS
 
 	pemFile := ""
 	if v.connInfo.PrivateKey != "" {
-		pemFile, err := v.writePem()
+		var err error
+		pemFile, err = v.writePem()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Looks like v2 got half of the fix from #53, but was missing the other half, so local mode with a private key specified doesn't work correctly in v2. This fixes it.