### PR TITLE
Pem decode rest

### DIFF
--- a/mode/local_connection_extractor.go
+++ b/mode/local_connection_extractor.go
@@ -110,6 +110,9 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		}
 		if connInfo.BastionPrivateKey == "" {
 			connInfo.BastionPrivateKey = connInfo.PrivateKey
+		} else {
+			block, _ := pem.Decode([]byte(connInfo.BastionPrivateKey))
+			connInfo.BastionPrivateKey = string(pem.EncodeToMemory(block))
 		}
 		if connInfo.BastionPort == 0 {
 			connInfo.BastionPort = connInfo.Port

--- a/mode/local_connection_extractor.go
+++ b/mode/local_connection_extractor.go
@@ -2,6 +2,7 @@ package mode
 
 import (
 	"encoding/pem"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -92,8 +93,10 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	}
 
 	if connInfo.PrivateKey != "" {
-
 		block, _ := pem.Decode([]byte(connInfo.PrivateKey))
+		if block == nil || block.Type != "RSA PRIVATE KEY" {
+			return nil, fmt.Errorf("Failed to decode private key")
+		}
 		connInfo.PrivateKey = string(pem.EncodeToMemory(block))
 	}
 	// Default all bastion config attrs to their non-bastion counterparts
@@ -112,6 +115,9 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 			connInfo.BastionPrivateKey = connInfo.PrivateKey
 		} else {
 			block, _ := pem.Decode([]byte(connInfo.BastionPrivateKey))
+			if block == nil || block.Type != "RSA PRIVATE KEY" {
+				return nil, fmt.Errorf("Failed to decode private key")
+			}
 			connInfo.BastionPrivateKey = string(pem.EncodeToMemory(block))
 		}
 		if connInfo.BastionPort == 0 {

--- a/mode/local_connection_extractor.go
+++ b/mode/local_connection_extractor.go
@@ -1,6 +1,7 @@
 package mode
 
 import (
+	"encoding/pem"
 	"log"
 	"os"
 	"time"
@@ -90,6 +91,11 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		connInfo.TimeoutVal = DefaultTimeout
 	}
 
+	if connInfo.PrivateKey != "" {
+
+		block, _ := pem.Decode([]byte(connInfo.PrivateKey))
+		connInfo.PrivateKey = string(pem.EncodeToMemory(block))
+	}
 	// Default all bastion config attrs to their non-bastion counterparts
 	if connInfo.BastionHost != "" {
 		// Format the bastion host if needed.


### PR DESCRIPTION
### Summary

fix #95 
use encoding/pem library to filter any extraneous bits attached to the key