### PR TITLE
fix and in-dockerfile-build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+FROM golang:1.11.4-alpine
+WORKDIR /go/src/github.com/radekg/terraform-provisioner-ansible/
+ADD . .
+RUN go build -o /go/bin/terraform-provisioner-ansible .
+
 FROM hashicorp/terraform:light
-ARG TAP_VERSION=2.0.1
-RUN apk update && apk add ansible bash
-ADD https://github.com/radekg/terraform-provisioner-ansible/releases/download/v${TAP_VERSION}/terraform-provisioner-ansible-linux-amd64_v${TAP_VERSION} /root/.terraform.d/plugins/terraform-provisioner-ansible
-RUN chmod 755 /root/.terraform.d/plugins/terraform-provisioner-ansible
+RUN apk update && apk add ansible && mkdir -p /root/.terraform.d/plugins/
+COPY --from=0 /go/bin/terraform-provisioner-ansible /root/.terraform.d/plugins/

--- a/mode/mode_remote.go
+++ b/mode/mode_remote.go
@@ -23,7 +23,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-const installerProgramTemplate = `#!/usr/bin/env sh
+const installerProgramTemplate = `#!/usr/bin/env bash
 if [ -z "$(which ansible-playbook)" ]; then
   
   # only check the cloud boot finished if the directory exists


### PR DESCRIPTION
### Summary

#### Fix the "/tmp/tf-ansible-installer: [[: not found"

Created vm with debian 9, and got an error.

    digitalocean_droplet.gitlab: Provisioning with 'ansible'...
    digitalocean_droplet.gitlab (ansible): Connecting to remote host via SSH...
    digitalocean_droplet.gitlab (ansible):   Host: 157.230.29.178
    digitalocean_droplet.gitlab (ansible):   User: root
    digitalocean_droplet.gitlab (ansible):   Password: false
    digitalocean_droplet.gitlab (ansible):   Private key: true
    digitalocean_droplet.gitlab (ansible):   SSH Agent: false
    digitalocean_droplet.gitlab (ansible):   Checking Host Key: false
    digitalocean_droplet.gitlab: Still creating... (50s elapsed)
    digitalocean_droplet.gitlab (ansible): Connected!
    digitalocean_droplet.gitlab (ansible): Uploading the parent directory '.' of playbook 'gitlab.yml' to '/tmp/tf-ansible-bootstrap/5058f1af8388633f609cadb75a75dc9d'...
    digitalocean_droplet.gitlab: Still creating... (1m0s elapsed)
    digitalocean_droplet.gitlab: Still creating... (1m10s elapsed)
    digitalocean_droplet.gitlab (ansible): Generating temporary ansible inventory...
    digitalocean_droplet.gitlab (ansible): Writing temporary ansible inventory to '/tmp/tf-ansible-bootstrap/5058f1af8388633f609cadb75a75dc9d/.inventory-91c92f8d-07df-40f4-9ff9-b026cd6d6e72'...
    digitalocean_droplet.gitlab (ansible): Ansible inventory written.
    digitalocean_droplet.gitlab (ansible): Installing Ansible 'ansible' using default installer...
    digitalocean_droplet.gitlab (ansible): Uploading Ansible installer program to '/tmp/tf-ansible-installer'...
    digitalocean_droplet.gitlab (ansible): /tmp/tf-ansible-installer: 6: /tmp/tf-ansible-installer: [[: not found

This simple fix will fix it.


#### Dockerfile

Now it have multi-stage build.

