### PR TITLE
Don't always set ANSIBLE_ROLE_PATH #109

### DIFF
--- a/types/play.go
+++ b/types/play.go
@@ -34,10 +34,6 @@ type Play struct {
 	overrideVaultPasswordFile string
 }
 
-var (
-	defaultRolesPath = []string{"~/.ansible/roles", "/usr/share/ansible/roles", "/etc/ansible/roles"}
-)
-
 const (
 	// default values:
 	playDefaultBecomeMethod = "sudo"

--- a/types/play.go
+++ b/types/play.go
@@ -371,7 +371,7 @@ func (v *Play) defaultRolePaths() []string {
 	if val, ok := os.LookupEnv(ansibleEnvVarDefaultRolesPath); ok {
 		return strings.Split(val, ":")
 	}
-	return defaultRolesPath
+	return []string{}
 }
 
 // ToCommand serializes the play to an executable Ansible command.
@@ -388,7 +388,11 @@ func (v *Play) ToCommand(ansibleArgs LocalModeAnsibleArgs) (string, error) {
 			rolePaths = append(rolePaths, filepath.Clean(rp))
 		}
 
-		command = fmt.Sprintf("%s %s=%s", command, ansibleEnvVarRolesPath, strings.Join(rolePaths, ":"))
+		// Only set ANSIBLE_ROLES_PATH when not empty.
+		if len(rolePaths) > 0 {
+			command = fmt.Sprintf("%s %s=%s", command, ansibleEnvVarRolesPath, strings.Join(rolePaths, ":"))
+		}
+
 		command = fmt.Sprintf("%s ansible-playbook %s", command, entity.FilePath())
 
 		// force handlers:


### PR DESCRIPTION
### Summary

Addresses issue #109 

When neither `ANSIBLE_ROLES_PATH` nor `DEFAULT_ROLES_PATH` environment variables are set,
`ANSIBLE_ROLES_PATH` is still set to defaultRolesPath. This avoid usage of `ansible.cfg` file, since `ANSIBLE_ROLES_PATH` has precedence over `ansible.cfg:role_path` attribute.

This PR is to avoid forcing `ANSIBLE_ROLES_PATH` when no path is provided, deferring to the `ansible.cfg` or ansible defaults when possible.
