### PR TITLE
add null_resource support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -141,3 +141,12 @@ After testing each of the examples, you will need to destroy the infrastructure.
         -var "vpc_cidr_block=${R_VPC_CIDR_BLOCK}" \
         -var "infrastructure_name=${R_NAME}-remote"
     ```
+
+5. `sshagent-local-no-bastion-null-resource`: run local provisioning using a null_resource for a host without a bastion
+    
+    ```
+    cd sshagent-local-no-bastion-null-resource
+    terraform apply -var "ami_id=${TERRAFORM_PROVISIONER_ANSIBLE_AMI_ID}"
+    # ...
+    terraform destroy -var "ami_id=${TERRAFORM_PROVISIONER_ANSIBLE_AMI_ID}"
+    ```

--- a/examples/sshagent-local-no-bastion-null-resource/main.tf
+++ b/examples/sshagent-local-no-bastion-null-resource/main.tf
@@ -1,0 +1,66 @@
+provider "aws" {
+  region  = "eu-central-1"
+  profile = "terraform-provisioner-ansible"
+}
+
+variable "ami_id" {}
+variable "insecure_no_strict_host_key_checking" {
+  default = false
+}
+
+## -- security groups:
+
+resource "aws_security_group" "ssh_box" {
+  name        = "ssh_box"
+  description = "SSH"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+## -- machine:
+
+resource "aws_instance" "test_box" {
+  ami           = "${var.ami_id}"
+  count         = "1"
+  instance_type = "m3.medium"
+
+  security_groups = ["${aws_security_group.ssh_box.name}"]
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size           = 8
+    volume_type           = "gp2"
+  }
+}
+
+
+resource "null_resource" "null01" {
+  connection {
+    user = "centos"
+  }
+  provisioner "ansible" {
+    plays {
+      playbook = {
+        file_path = "${path.module}/ansible-data/playbooks/install-tree.yml"
+        roles_path = [
+            "${path.module}/ansible-data/roles"
+        ]
+      }
+      groups = ["servers"]
+      hosts = ["${aws_instance.test_box.ipv4_address}"]
+    }
+  }    
+}

--- a/mode/ssh_target_host.go
+++ b/mode/ssh_target_host.go
@@ -3,6 +3,7 @@ package mode
 import (
 	"fmt"
 	"time"
+	
 
 	"golang.org/x/crypto/ssh"
 )

--- a/types/ansible_ssh_settings.go
+++ b/types/ansible_ssh_settings.go
@@ -16,6 +16,8 @@ type AnsibleSSHSettings struct {
 	insecureBastionNoStrictHostKeyChecking bool
 	userKnownHostsFile                     string
 	bastionUserKnownHostsFile              string
+	overrideStrictHostKeyChecking          bool
+
 }
 
 const (
@@ -136,8 +138,18 @@ func (v *AnsibleSSHSettings) SSHKeyscanSeconds() int {
 
 // InsecureNoStrictHostKeyChecking if true, SSH to the target host uses -o StrictHostKeyChecking=no.
 func (v *AnsibleSSHSettings) InsecureNoStrictHostKeyChecking() bool {
-	return v.insecureNoStrictHostKeyChecking
+	if v.overrideStrictHostKeyChecking || v.insecureNoStrictHostKeyChecking {
+		return true
+	} else {
+		return false
+	}
 }
+
+// SetOverrideStrictHostKeyChecking is used by the provisioner when attached to a null_resource
+func (v *AnsibleSSHSettings) SetOverrideStrictHostKeyChecking() {
+	v.overrideStrictHostKeyChecking  = true
+}
+
 
 // InsecureBastionNoStrictHostKeyChecking if true, SSH to the bastion host uses -o StrictHostKeyChecking=no.
 func (v *AnsibleSSHSettings) InsecureBastionNoStrictHostKeyChecking() bool {

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -33,7 +33,7 @@ func vfBecomeMethod(val interface{}, key string) (warns []string, errs []error) 
 func vfPath(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 	if strings.Index(v, "${path.module}") > -1 {
-		warns = append(warns, fmt.Sprintf("I could not reliably determine the existence of '%s', most likely because of https://github.com/hashicorp/terraform/issues/17439. If the file does not exist, you'll experience a failure at runtime.", v))
+		warns = append(warns, fmt.Sprintf("Unable to determine the existence of '%s', most likely because of https://github.com/hashicorp/terraform/issues/17439. If the file does not exist, you'll experience a failure at runtime.", v))
 	} else {
 		if _, err := ResolvePath(v); err != nil {
 			errs = append(errs, fmt.Errorf("file '%s' does not exist", v))
@@ -46,10 +46,10 @@ func vfPath(val interface{}, key string) (warns []string, errs []error) {
 func VfPathDirectory(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 	if strings.Index(v, "${path.module}") > -1 {
-		warns = append(warns, fmt.Sprintf("I could not reliably determine the existence of '%s', most likely because of https://github.com/hashicorp/terraform/issues/17439. If the file does not exist, you'll experience a failure at runtime.", v))
+		warns = append(warns, fmt.Sprintf("Unable to determine the existence of '%s', most likely because of https://github.com/hashicorp/terraform/issues/17439. If the file does not exist, you'll experience a failure at runtime.", v))
 	} else {
 		if _, err := ResolveDirectory(v); err != nil {
-			errs = append(errs, fmt.Errorf("directory '%s' does not exist or path not directory", v))
+			errs = append(errs, fmt.Errorf("directory '%s' does not exist or path is not a directory", v))
 		}
 	}
 	return

--- a/types/play.go
+++ b/types/play.go
@@ -523,7 +523,8 @@ func (v *Play) toCommandArguments(ansibleArgs LocalModeAnsibleArgs, ansibleSSHSe
 	sshExtraAgrsOptions = append(sshExtraAgrsOptions, fmt.Sprintf("-p %d", ansibleArgs.Port))
 	sshExtraAgrsOptions = append(sshExtraAgrsOptions, fmt.Sprintf("-o ConnectTimeout=%d", ansibleSSHSettings.ConnectTimeoutSeconds()))
 	sshExtraAgrsOptions = append(sshExtraAgrsOptions, fmt.Sprintf("-o ConnectionAttempts=%d", ansibleSSHSettings.ConnectAttempts()))
-	if ansibleSSHSettings.InsecureNoStrictHostKeyChecking() {
+	
+	if ansibleSSHSettings.InsecureNoStrictHostKeyChecking() || v.InventoryFile() != "" {
 		sshExtraAgrsOptions = append(sshExtraAgrsOptions, "-o StrictHostKeyChecking=no")
 	} else {
 		if ansibleSSHSettings.UserKnownHostsFile() != "" {
@@ -539,7 +540,7 @@ func (v *Play) toCommandArguments(ansibleArgs LocalModeAnsibleArgs, ansibleSSHSe
 		if ansibleArgs.BastionPemFile != "" {
 			proxyCommand = fmt.Sprintf("%s -i %s", proxyCommand, ansibleArgs.BastionPemFile)
 		}
-		if ansibleSSHSettings.InsecureBastionNoStrictHostKeyChecking() {
+		if ansibleSSHSettings.InsecureBastionNoStrictHostKeyChecking()  {
 			proxyCommand = fmt.Sprintf("%s -o StrictHostKeyChecking=no", proxyCommand)
 		} else {
 			if ansibleSSHSettings.BastionUserKnownHostsFile() != "" {


### PR DESCRIPTION
### Summary

Added support to allow terraform-provisioner-ansible to be used in local_mode with a null_resource. Target hosts for the provisioner can be specified using `plays.hosts` and interpolation from the ip_address of provisioned compute instances, or by passing an inventory file. 

Included updates to Readme and an additional example. 

Using `terraform taint null_resource.xxxxxxx` the provisioner can be triggered to run again on the next `terraform apply`. 

Extensively tested on IBM Cloud. Operation will be the same across all cloud vendors.

>>>> 
Additional comment:
I found when the provisioner is used with a compute resource, it is not necessary to specify a host in the connection block or with plays.hosts. If connection.host is not specified, Terraform passes the public IP address of the instance just created. This usage was not clear in the Readme. 