### PR TITLE
Ensure that the output from remote provisioner command contains valid…

### DIFF
--- a/mode/mode_remote.go
+++ b/mode/mode_remote.go
@@ -598,7 +598,9 @@ func (v *RemoteMode) copyOutput(r io.Reader, doneCh chan<- struct{}) {
 	defer close(doneCh)
 	lr := linereader.New(r)
 	for line := range lr.Ch {
-		v.o.Output(line)
+		// Use strings.ToValidUTF8 to avoid RPC errors:
+		// https://github.com/radekg/terraform-provisioner-ansible/issues/139
+		v.o.Output(strings.ToValidUTF8(line, ""))
 	}
 }
 


### PR DESCRIPTION
… UTF-8. Closes #139.

### Summary

As per https://github.com/hashicorp/terraform/issues/22856#issuecomment-533300018, relevant bit:

```
The Terraform language and protocols consider
strings to be unicode and thus requires strings
arriving via wire protocols to be UTF-8 encoded,
so unfortunately it's by design that non-UTF-8
strings cannot be returned here, but since this
seems to just be general progress output emitted
by the provisioner, it is probably okay for the
provisioner to pre-sanitize these strings to replace
non-UTF-8 sequences with the replacement
character so that the rest of the message is still
readable.
```

This PR attempts to fix the problem.
