### PR TITLE
Remote provisioning will hang on cloud instances

### DIFF
--- a/mode/mode_remote.go
+++ b/mode/mode_remote.go
@@ -33,7 +33,7 @@ set -euo pipefail
 if [ -z "$(which ansible-playbook)" ]; then
   # only check the cloud boot finished if the directory exists
   if [ -d /var/lib/cloud/instance ]; then
-    while [ -f /var/lib/cloud/instance/boot-finished ]; do
+    while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
       sleep 1
     done
   fi


### PR DESCRIPTION
### Summary

If the file `/var/lib/cloud/instance/boot-finished` exists, the remote installer will never continue the way the bash script is written.

This was never an issue before, as you had used `until` instead of `while` previously.

### Other Information

Is there anything else relevant to your pull request? Please mention it here.

Thank you for contributing!
