### PR TITLE
Fix curl call and bash call

### DIFF
--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -57,7 +57,7 @@ download_url="https://github.com/radekg/terraform-provisioner-ansible/releases/d
 
 # GitHub stores files under a different URL, thus it redirects, we are looking for 302:
 echo "Checking existence of ${download_url}..."
-status=`curl -sSI HEAD "${download_url}" | grep 'Status:' | awk '{ print $2 }'`
+status=`curl -sSI "${download_url}" | grep -i 'status:' | awk '{ print $2 }'`
 
 if [ "$status" != "302" ]; then
   echo "Error: no release available for ${ostype}, version ${version}\n\tat ${download_url}" >&2

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 architecture=amd64


### PR DESCRIPTION
### Summary

* Fix curl call
* Fix #148 by the same way on `bash` vs `sh`

### Other Information

* `status` is now lower case
* `curl -I` does not require HEAD and lead to HEAD being tried to be resolved which fails.
* Use `bash` and not only `sh` to prevent errors