### PR TITLE
update the deploy-release.sh script

### DIFF
--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -57,7 +57,7 @@ download_url="https://github.com/radekg/terraform-provisioner-ansible/releases/d
 
 # GitHub stores files under a different URL, thus it redirects, we are looking for 302:
 echo "Checking existence of ${download_url}..."
-status=`curl -sSI "${download_url}" | grep -I 'HTTP/2 ' | awk '{ print $2 }'`
+status=`curl -sSI "${download_url}" | grep -i 'HTTP/2 ' | awk '{ print $2 }'`
 
 if [ "$status" != "302" ]; then
   echo "Error: no release available for ${ostype}, version ${version}\n\tat ${download_url}" >&2

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -57,7 +57,7 @@ download_url="https://github.com/radekg/terraform-provisioner-ansible/releases/d
 
 # GitHub stores files under a different URL, thus it redirects, we are looking for 302:
 echo "Checking existence of ${download_url}..."
-status=`curl -sSI "${download_url}" | grep -i 'status:' | awk '{ print $2 }'`
+status=`curl -sSI "${download_url}" | grep -I 'HTTP/2 ' | awk '{ print $2 }'`
 
 if [ "$status" != "302" ]; then
   echo "Error: no release available for ${ostype}, version ${version}\n\tat ${download_url}" >&2


### PR DESCRIPTION
### Summary

`curl -i` is not returning a `status:` header, it is now `HTTP/2`, so the `deploy-release.sh` script is not working anymore.

Before this change, the script would just exit 1 with no log messages saying what happened and the release was not downloaded.

Here is some of the output if you make the curl request:

```
$ curl -i https://github.com/radekg/terraform-provisioner-ansible/releases/download/v2.5.0/terraform-provisioner-ansible-linux-amd64_v2.5.0
HTTP/2 302 
server: GitHub.com
date: Tue, 30 Mar 2021 18:23:39 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, Accept-Encoding, Accept, X-Requested-With
...<removed>...
```